### PR TITLE
ci(test): add timeout to galaxy install command

### DIFF
--- a/.github/workflows/code_testing.yml
+++ b/.github/workflows/code_testing.yml
@@ -74,7 +74,7 @@ jobs:
           python3 -m pip install -r .github/workflows/requirements.txt -c .github/workflows/constraints.txt
           molecule --version
           docker --version
-          ansible-galaxy install -r requirements.yml
+          ansible-galaxy install --timeout 120 --verbose -r requirements.yml
           ansible-galaxy collection list
 
       - if: ${{ matrix.ansible_version_minimum }}


### PR DESCRIPTION
Since the CI pipeline often suffers from timeouts there is now a flag to
higher the timeout