### PR TITLE
 fix(preparation): Add conditions to allow binary installation of version newer than 2.6.1

### DIFF
--- a/tasks/preparation/ntfy_release.yml
+++ b/tasks/preparation/ntfy_release.yml
@@ -37,7 +37,11 @@
     - name: Set download link
       ansible.builtin.set_fact:
         _release_download_url: "https://github.com/binwiederhier/ntfy/releases/download/v{{ ntfy_version }}/ntfy_{{ ntfy_version }}_linux_{{ release_binary_arch }}.tar.gz"
-
+      when: ntfy_version is version('2.6.1', '>=') 
+    - name: Set download link
+      ansible.builtin.set_fact:
+        _release_download_url: "https://github.com/binwiederhier/ntfy/releases/download/v{{ ntfy_version }}/ntfy_{{ ntfy_version }}_linux_{{ release_binary_arch_old }}.tar.gz"
+      when: ntfy_version is version('2.6.1', '<') 
     - name: Probe download link is valid
       ansible.builtin.uri:
         url: "{{ _release_download_url }}"

--- a/vars/architecture_map.yml
+++ b/vars/architecture_map.yml
@@ -1,5 +1,12 @@
 ---
 binary_arch_map:
+  i386: 'amd64'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'armv7'
+  armv6l: 'armv6'
+
+binary_arch_map_old:
   i386: 'x86_64'
   x86_64: 'x86_64'
   aarch64: 'arm64'


### PR DESCRIPTION
Summary : Add a when statement and a map to allow installation of version of ntfy newer than 2.6.1
Changes in tarball/zip naming:
Due to a [change in GoReleaser](https://goreleaser.com/deprecations/#archivesreplacements), some of the binary release
archives now have slightly different names. My apologies if this causes issues in the downstream projects that use ntfy:

    ntfy_v${VERSION}_windows_x86_64.zip -> ntfy_v${VERSION}_windows_amd64.zip
    ntfy_v${VERSION}_linux_x86_64.tar.gz -> ntfy_v${VERSION}_linux_amd64.tar.gz
    ntfy_v${VERSION}_macOS_all.tar.gz -> ntfy_v${VERSION}_darwin_all.tar.gz